### PR TITLE
Fix type definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,3 @@
-export async function confirm(): Promise<boolean>;
+export function confirm(): Promise<boolean>;
+
+export { confirm as areYouSure }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,3 @@
-export function confirm(): Promise<boolean>;
+export function confirm(): Promise<true>;
 
 export { confirm as areYouSure }

--- a/src/legacy/require.d.cts
+++ b/src/legacy/require.d.cts
@@ -1,1 +1,1 @@
-module.exports.confirm = async function confirm(): Promise<boolean>;
+export function confirm(): Promise<boolean>;

--- a/src/legacy/require.d.cts
+++ b/src/legacy/require.d.cts
@@ -1,1 +1,1 @@
-export function confirm(): Promise<boolean>;
+export function confirm(): Promise<true>;


### PR DESCRIPTION
The type definitions for the `confirm` export for both the require and the import export contained syntax errors. This is now fixed.

This also adds the missing `areYouSure` export in the ESM type definitions.